### PR TITLE
fix: added missing permissions for CI action runs

### DIFF
--- a/.github/workflows/generate_tf_docs.yaml
+++ b/.github/workflows/generate_tf_docs.yaml
@@ -4,6 +4,8 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
# Description

Added missing permissions to automatically update the documentation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
