### PR TITLE
fix: reference to cluster name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "argocd_application_set" "this" {
             "application-set" = var.name
           },
           {
-            for k, v in var.env_context_annotations : k => "{{ $applicationName := \"${var.name}\" }}{{ $resourceName := \"${local.resource_name}\" }}{{ $cluster := \"\" }}{{ if eq (index .Path.Segments 1) \"general-purpose\" }}{{ $cluster = \"in-cluster\" }}{{ else }}{{ $cluster = (index .Path.Segments 1) }}{{ end }}${v}"
+            for k, v in var.env_context_annotations : k => "{{ $applicationName := \"${var.name}\" }}{{ $resourceName := \"${local.resource_name}\" }}{{ $cluster := \"\" }}{{ if eq ${local.cluster_identifier} \"general-purpose\" }}{{ $cluster = \"in-cluster\" }}{{ else }}{{ $cluster = ${local.cluster_identifier} }}{{ end }}${v}"
           }
         )
         labels = merge(


### PR DESCRIPTION
# Description

Fixed ArgoCD cluster name reference in annotation mapping.

Ticket: TPLAT-287

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
