### PR TITLE
fix: argocd namespace overwrite in property file

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,7 +128,7 @@ resource "argocd_application_set" "this" {
           // (e.g. background-staging (assuming "background" is the project and "staging" the folder name))
           // otherwise we use the namespace_overwrite provided by the developer
           // (e.g. background-staging-v2 (assuming "background" is the project and "staging-v2" the namespace_overwrite))
-          namespace = var.target_namespace_overwrite != "" ? var.target_namespace_overwrite : "{{ if not .namespace_overwrite }}${var.project_name}-${local.resource_name}{{ else }}${var.project_name}-{{ .namespace_overwrite }}{{ end }}"
+          namespace = var.target_namespace_overwrite != "" ? var.target_namespace_overwrite : "{{ if not .namespace_overwrite }}${var.project_name}-${local.resource_name}{{ else }}{{ .namespace_overwrite }}{{ end }}"
         }
         sync_policy {
           dynamic "automated" {


### PR DESCRIPTION
# Description

To manage the namespace to be targeted in the property values file, we should generate the namespace name *not* based on the project name and the overridden property.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
